### PR TITLE
Fix unescaped entity in page.tsx

### DIFF
--- a/src/slices/SkyDive/Scene.tsx
+++ b/src/slices/SkyDive/Scene.tsx
@@ -187,7 +187,7 @@ function ThreeText({
       fontWeight={900}
       anchorX={"center"}
       anchorY={"middle"}
-      characters="ABCDEFGHIJKLMNOPQRSTUVWXYZ!,.?'"
+      characters="ABCDEFGHIJKLMNOPQRSTUVWXYZ!,.?&apos;"
     >
       {word}
     </Text>


### PR DESCRIPTION
Fixes ESLint `react/no-unescaped-entities` error by escaping an apostrophe in `src/slices/SkyDive/Scene.tsx`.

---

[Open in Web](https://cursor.com/agents?id=bc-1b0e8ca1-832b-4c4e-b512-731256eaf998) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1b0e8ca1-832b-4c4e-b512-731256eaf998) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)